### PR TITLE
move react* to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "chai": "^3.3.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3"
   },
   "dependencies": {
     "babel-polyfill": "^6.2.0",
     "c3": "^0.4.10",
-    "deepmerge": "^0.2.10",
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "deepmerge": "^0.2.10"
   }
 }


### PR DESCRIPTION
I think the react and react-dom must be in devDependencies instead. This should fix #2 on release