### PR TITLE
enable div to accept more props

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "babel-polyfill": "^6.2.0",
     "c3": "^0.4.10",
-    "deepmerge": "^0.2.10"
+    "deepmerge": "^0.2.10",
+    "filter-react-dom-props": "0.0.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import c3 from 'c3';
 import merge from 'deepmerge';
 import loadHistoryData from './loadHistoricalData';
+import filterReactDomProps from 'filter-react-dom-props';
 
 const isDate = (key) => key === "date";
 const isList = (data) => data && data.length;
@@ -87,7 +88,7 @@ var RTChart = React.createClass({
   },
 
   render: function() {
-    return <div style = { this.props.style } ref='chart'/>
+    return <div {...filterReactDomProps(this.props)} ref='chart'/>
   },
 
   initChart: function(props) {


### PR DESCRIPTION
Hi @emilmork 

In order to transfer all props to the div but also avoid Unknown prop warning, I use another library [filter-react-dom-props](https://github.com/twobin/filter-react-dom-props) to help filter invalid props out. Please check the comparison, thanks.